### PR TITLE
Remove "awards" endpoints

### DIFF
--- a/src/SpurClient.php
+++ b/src/SpurClient.php
@@ -507,23 +507,6 @@ class SpurClient extends SpurClientBase
         return $this->post('shifts/workplace/bulk-tips', $params);
     }
 
-    // Awards
-
-    public function createAwards(array $params)
-    {
-        return $this->post('shift-awards', $params);
-    }
-
-    public function updateAward(int $award_id, array $params)
-    {
-        return $this->put("awards/{$award_id}", $params);
-    }
-
-    public function deleteAward(int $award_id)
-    {
-        return $this->delete("awards/{$award_id}");
-    }
-
     // Workers
 
     public function getBlockedWorkers(int $place_id, array $params)


### PR DESCRIPTION
The "awards" endpoints are obsolete and unused in Spur Web `develop`. We can remove them.